### PR TITLE
Display teacher course management menu

### DIFF
--- a/educa/courses/templates/base.html
+++ b/educa/courses/templates/base.html
@@ -11,6 +11,12 @@
       <a href="/" class="logo">GoStack</a>
       <ul class="menu">
         {% if request.user.is_authenticated %}
+          {% if perms.courses.view_course %}
+            <li><a href="{% url 'manage_course_list' %}">Управление курсами</a></li>
+          {% endif %}
+          {% if perms.courses.add_course %}
+            <li><a href="{% url 'course_create' %}">Создать курс</a></li>
+          {% endif %}
           <li>
             <form action="{% url "logout" %}" method="post">
               <button type="submit">Выйти из системы</button>


### PR DESCRIPTION
## Summary
- show course management links on the base template when the logged-in user has the appropriate permissions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842fff256dc8328a933f6fcbe69c4ac