### PR TITLE
Fix course detail view when course has no modules

### DIFF
--- a/educa/students/templates/students/course/detail.html
+++ b/educa/students/templates/students/course/detail.html
@@ -6,9 +6,13 @@
 {% endblock %}
 
 {% block content %}
-  <h1>
-    {{ module.title }}
-  </h1>
+  {% if module %}
+    <h1>
+      {{ module.title }}
+    </h1>
+  {% else %}
+    <h1>В курсе пока нет модулей</h1>
+  {% endif %}
   <div class="contents">
     <h3>Модули</h3>
     <ul id="modules">
@@ -32,14 +36,18 @@
       </a>
     </h3>
   </div>
-  <div class="module">
-    {% cache 600 module_contents module %}
-      {% for content in module.contents.all %}
-        {% with item=content.item %}
-          <h2>{{ item.title }}</h2>
-          {{ item.render }}
-        {% endwith %}
-      {% endfor %}
-    {% endcache %}
-  </div>
+  {% if module %}
+    <div class="module">
+      {% cache 600 module_contents module %}
+        {% for content in module.contents.all %}
+          {% with item=content.item %}
+            <h2>{{ item.title }}</h2>
+            {{ item.render }}
+          {% endwith %}
+        {% empty %}
+          <p>Материалов пока нет.</p>
+        {% endfor %}
+      {% endcache %}
+    </div>
+  {% endif %}
 {% endblock %}

--- a/educa/students/views.py
+++ b/educa/students/views.py
@@ -61,12 +61,15 @@ class StudentCourseDetailView(LoginRequiredMixin, DetailView):
         context = super().get_context_data(**kwargs)
         # get course object
         course = self.get_object()
-        if 'module_id' in self.kwargs:
-            # get current module
-            context['module'] = course.modules.get(
-                id=self.kwargs['module_id']
-            )
+        if course.modules.exists():
+            if 'module_id' in self.kwargs:
+                # get current module
+                context['module'] = course.modules.get(
+                    id=self.kwargs['module_id']
+                )
+            else:
+                # get first module
+                context['module'] = course.modules.first()
         else:
-            # get first module
-            context['module'] = course.modules.all()[0]
+            context['module'] = None
         return context


### PR DESCRIPTION
## Summary
- handle courses without modules
- guard template to show message when no modules exist

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68442f0ef3608328befce5b63b21010b