### PR TITLE
Fix logout CSRF token placement and module OrderField

### DIFF
--- a/educa/courses/models.py
+++ b/educa/courses/models.py
@@ -47,7 +47,7 @@ class Module(models.Model):
     )
     title = models.CharField('Название', max_length=200)
     description = models.TextField('Описание', blank=True)
-    order = OrderField('Порядок', blank=True, for_fields=['course'])
+    order = OrderField(verbose_name='Порядок', blank=True, for_fields=['course'])
 
     class Meta:
         ordering = ['order']

--- a/educa/courses/templates/base.html
+++ b/educa/courses/templates/base.html
@@ -19,9 +19,9 @@
           {% endif %}
           <li><a href="{% url 'student_course_list' %}">Мои курсы</a></li>
           <li>
-            <form action="{% url "logout" %}" method="post">
-              <button type="submit">Выйти из системы</button>
+            <form action="{% url 'logout' %}" method="post">
               {% csrf_token %}
+              <button type="submit">Выйти из системы</button>
             </form>
           </li>
         {% else %}


### PR DESCRIPTION
## Summary
- place `csrf_token` before the logout button in `base.html`
- correct `OrderField` initialization in `Module` model

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68455a7042808328bdbe66ed96bb6d94