### PR TITLE
Allow logout via GET to avoid stale CSRF

### DIFF
--- a/educa/courses/models.py
+++ b/educa/courses/models.py
@@ -47,7 +47,7 @@ class Module(models.Model):
     )
     title = models.CharField('Название', max_length=200)
     description = models.TextField('Описание', blank=True)
-    order = OrderField('Порядок', blank=True, for_fields=['course'])
+    order = OrderField(verbose_name='Порядок', blank=True, for_fields=['course'])
 
     class Meta:
         ordering = ['order']

--- a/educa/courses/templates/base.html
+++ b/educa/courses/templates/base.html
@@ -19,9 +19,9 @@
           {% endif %}
           <li><a href="{% url 'student_course_list' %}">Мои курсы</a></li>
           <li>
-            <form action="{% url "logout" %}" method="post">
-              <button type="submit">Выйти из системы</button>
+            <form action="{% url 'logout' %}" method="post">
               {% csrf_token %}
+              <button type="submit">Выйти из системы</button>
             </form>
           </li>
         {% else %}

--- a/educa/educa/urls.py
+++ b/educa/educa/urls.py
@@ -21,6 +21,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
+from .views import LogoutViewAllowGet
 from django.urls import include, path
 
 urlpatterns = [
@@ -29,7 +30,7 @@ urlpatterns = [
     ),
     path(
         'accounts/logout/',
-        auth_views.LogoutView.as_view(),
+        LogoutViewAllowGet.as_view(),
         name='logout',
     ),
     path('admin/', admin.site.urls),

--- a/educa/educa/views.py
+++ b/educa/educa/views.py
@@ -1,0 +1,8 @@
+from django.contrib.auth.views import LogoutView
+
+class LogoutViewAllowGet(LogoutView):
+    """Allow logout via GET requests for convenience."""
+
+    def get(self, request, *args, **kwargs):
+        """Redirect GET requests to POST to avoid CSRF issues with stale pages."""
+        return self.post(request, *args, **kwargs)


### PR DESCRIPTION
## Summary
- introduce `LogoutViewAllowGet` that forwards GET requests to LogoutView.post
- register `LogoutViewAllowGet` in URL configuration

## Testing
- `DJANGO_SETTINGS_MODULE=educa.settings.local python educa/manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68455a7042808328bdbe66ed96bb6d94