### PR TITLE
Update course overview to hide enroll button for enrolled users

### DIFF
--- a/educa/courses/templates/courses/course/detail.html
+++ b/educa/courses/templates/courses/course/detail.html
@@ -19,11 +19,20 @@
       </p>
       {{ object.overview|linebreaks }}
       {% if request.user.is_authenticated %}
-        <form action="{% url "student_enroll_course" %}" method="post">
-          {{ enroll_form }}
-          {% csrf_token %}
-          <input type="submit" value="Записаться">
-        </form>
+        {% if is_enrolled %}
+          <p>
+            Вы уже записаны на этот курс.
+            <a href="{% url "student_course_detail" object.id %}" class="button">
+              Перейти к материалам
+            </a>
+          </p>
+        {% else %}
+          <form action="{% url "student_enroll_course" %}" method="post">
+            {{ enroll_form }}
+            {% csrf_token %}
+            <input type="submit" value="Записаться">
+          </form>
+        {% endif %}
       {% else %}
         <a href="{% url "student_registration" %}" class="button">
           Зарегистрируйтесь, чтобы записаться

--- a/educa/courses/views.py
+++ b/educa/courses/views.py
@@ -229,4 +229,10 @@ class CourseDetailView(DetailView):
         context['enroll_form'] = CourseEnrollForm(
             initial={'course': self.object}
         )
+        if self.request.user.is_authenticated:
+            context['is_enrolled'] = self.object.students.filter(
+                id=self.request.user.id
+            ).exists()
+        else:
+            context['is_enrolled'] = False
         return context


### PR DESCRIPTION
## Summary
- adjust course detail template to remove enroll form when user is already enrolled
- add `is_enrolled` context flag in `CourseDetailView`

## Testing
- `python educa/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684566f98df48328a14ec794907a463f