### PR TITLE
Enhance module management

### DIFF
--- a/educa/courses/forms.py
+++ b/educa/courses/forms.py
@@ -1,11 +1,21 @@
-from django.forms.models import inlineformset_factory
+from django.forms.models import inlineformset_factory, BaseInlineFormSet
 
 from .models import Course, Module
+
+
+class ModuleBaseFormSet(BaseInlineFormSet):
+    """Formset for modules with Russian delete label."""
+
+    def add_fields(self, form, index):
+        super().add_fields(form, index)
+        if self.can_delete and 'DELETE' in form.fields:
+            form.fields['DELETE'].label = 'Удалить'
 
 ModuleFormSet = inlineformset_factory(
     Course,
     Module,
+    formset=ModuleBaseFormSet,
     fields=['title', 'description'],
-    extra=2,
+    extra=10,
     can_delete=True,
 )

--- a/educa/courses/templates/courses/manage/module/formset.html
+++ b/educa/courses/templates/courses/manage/module/formset.html
@@ -9,9 +9,13 @@
   <div class="module">
     <h2>Модули курса</h2>
     <form method="post">
-      {{ formset }}
       {{ formset.management_form }}
       {% csrf_token %}
+      <ul id="course-modules">
+        {% for form in formset %}
+          <li>{{ form.as_p }}</li>
+        {% endfor %}
+      </ul>
       <input type="submit" value="Сохранить модули">
     </form>
   </div>


### PR DESCRIPTION
## Summary
- increase default extra module forms and add Russian label for deletion checkbox
- render module formset as list for better alignment

## Testing
- `python educa/manage.py check`
- `python educa/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684569f204e48328870be4a476827c6c