### PR TITLE
Improve module form UX

### DIFF
--- a/educa/courses/forms.py
+++ b/educa/courses/forms.py
@@ -1,10 +1,20 @@
-from django.forms.models import inlineformset_factory
+from django.forms.models import inlineformset_factory, BaseInlineFormSet
 
 from .models import Course, Module
+
+
+class ModuleBaseFormSet(BaseInlineFormSet):
+    """Formset for modules with Russian delete label."""
+
+    def add_fields(self, form, index):
+        super().add_fields(form, index)
+        if self.can_delete and 'DELETE' in form.fields:
+            form.fields['DELETE'].label = 'Удалить'
 
 ModuleFormSet = inlineformset_factory(
     Course,
     Module,
+    formset=ModuleBaseFormSet,
     fields=['title', 'description'],
     extra=2,
     can_delete=True,

--- a/educa/courses/templates/courses/manage/module/formset.html
+++ b/educa/courses/templates/courses/manage/module/formset.html
@@ -9,10 +9,31 @@
   <div class="module">
     <h2>Модули курса</h2>
     <form method="post">
-      {{ formset }}
       {{ formset.management_form }}
       {% csrf_token %}
+      <ul id="course-modules" data-prefix="{{ formset.prefix }}">
+        {% for form in formset %}
+          <li>{{ form.as_p }}</li>
+        {% endfor %}
+        <li id="empty-form" class="hidden">{{ formset.empty_form.as_p }}</li>
+      </ul>
+      <a href="#" id="add-module" class="secondary-button">Добавить модуль</a>
       <input type="submit" value="Сохранить модули">
     </form>
   </div>
+{% endblock %}
+
+{% block domready %}
+  document.querySelector('#add-module').addEventListener('click', function(e) {
+    e.preventDefault();
+    const modules = document.querySelector('#course-modules');
+    const prefix = modules.dataset.prefix;
+    const totalForms = document.querySelector('#id_' + prefix + '-TOTAL_FORMS');
+    const formCount = parseInt(totalForms.value, 10);
+    const empty = document.querySelector('#empty-form');
+    const newForm = document.createElement('li');
+    newForm.innerHTML = empty.innerHTML.replace(/__prefix__/g, formCount);
+    modules.insertBefore(newForm, empty);
+    totalForms.value = formCount + 1;
+  });
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow adding modules dynamically
- revert extra blank module forms to 2

## Testing
- `python educa/manage.py check`
- `python educa/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_684569f204e48328870be4a476827c6c