### PR TITLE
Fix cache invalidation for course lists

### DIFF
--- a/educa/courses/apps.py
+++ b/educa/courses/apps.py
@@ -4,3 +4,8 @@ from django.apps import AppConfig
 class CoursesConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'courses'
+
+    def ready(self):
+        # register signal handlers
+        from . import signals  # noqa: F401
+

--- a/educa/courses/forms.py
+++ b/educa/courses/forms.py
@@ -1,11 +1,21 @@
-from django.forms.models import inlineformset_factory
+from django.forms.models import inlineformset_factory, BaseInlineFormSet
 
 from .models import Course, Module
+
+
+class ModuleBaseFormSet(BaseInlineFormSet):
+    """Formset for modules with Russian delete label."""
+
+    def add_fields(self, form, index):
+        super().add_fields(form, index)
+        if self.can_delete and 'DELETE' in form.fields:
+            form.fields['DELETE'].label = 'Удалить'
 
 ModuleFormSet = inlineformset_factory(
     Course,
     Module,
+    formset=ModuleBaseFormSet,
     fields=['title', 'description'],
-    extra=2,
+    extra=0,
     can_delete=True,
 )

--- a/educa/courses/signals.py
+++ b/educa/courses/signals.py
@@ -1,0 +1,22 @@
+from django.db.models.signals import post_save, post_delete
+from django.dispatch import receiver
+from django.core.cache import cache
+
+from .models import Course, Module
+
+
+@receiver([post_save, post_delete], sender=Course)
+def clear_course_cache(sender, instance, **kwargs):
+    """Invalidate cached course listings when a course changes."""
+    cache.delete('all_courses')
+    cache.delete('all_subjects')
+    cache.delete(f'subject_{instance.subject.id}_courses')
+
+
+@receiver([post_save, post_delete], sender=Module)
+def clear_module_cache(sender, instance, **kwargs):
+    """Invalidate cached course lists when a module changes."""
+    subject_id = instance.course.subject.id
+    cache.delete('all_courses')
+    cache.delete('all_subjects')
+    cache.delete(f'subject_{subject_id}_courses')

--- a/educa/courses/templates/courses/manage/module/formset.html
+++ b/educa/courses/templates/courses/manage/module/formset.html
@@ -9,10 +9,31 @@
   <div class="module">
     <h2>Модули курса</h2>
     <form method="post">
-      {{ formset }}
       {{ formset.management_form }}
       {% csrf_token %}
+      <ul id="course-modules" data-prefix="{{ formset.prefix }}">
+        {% for form in formset %}
+          <li>{{ form.as_p }}</li>
+        {% endfor %}
+        <li id="empty-form" class="hidden">{{ formset.empty_form.as_p }}</li>
+      </ul>
+      <a href="#" id="add-module" class="secondary-button">Добавить модуль</a>
       <input type="submit" value="Сохранить модули">
     </form>
   </div>
+{% endblock %}
+
+{% block domready %}
+  document.querySelector('#add-module').addEventListener('click', function(e) {
+    e.preventDefault();
+    const modules = document.querySelector('#course-modules');
+    const prefix = modules.dataset.prefix;
+    const totalForms = document.querySelector('#id_' + prefix + '-TOTAL_FORMS');
+    const formCount = parseInt(totalForms.value, 10);
+    const empty = document.querySelector('#empty-form');
+    const newForm = document.createElement('li');
+    newForm.innerHTML = empty.innerHTML.replace(/__prefix__/g, formCount);
+    modules.insertBefore(newForm, empty);
+    totalForms.value = formCount + 1;
+  });
 {% endblock %}


### PR DESCRIPTION
## Summary
- invalidate cached course listings whenever courses or modules change
- register new signal handlers
- start module formset with zero extra forms

## Testing
- `python educa/manage.py check`
- `python educa/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_684569f204e48328870be4a476827c6c