### PR TITLE
Improve course management styles

### DIFF
--- a/educa/courses/static/css/base.css
+++ b/educa/courses/static/css/base.css
@@ -215,9 +215,13 @@ ul#course-modules {
     overflow:auto;
 }
 
+ul#course-modules input[type=text] {
+    width: 100%;
+}
+
 ul#course-modules textarea {
-    width:600px;
-    height:120px;
+    width: 100%;
+    height: 120px;
 }
 
 ul#course-modules li {
@@ -273,6 +277,21 @@ ul#course-modules li:hover {
 
 .course-info a {
     margin-right:10px;
+}
+
+.course-actions {
+    margin: 10px 0;
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.course-actions a {
+    display: inline-block;
+    margin-right: 15px;
+}
+
+.course-actions a:last-child {
+    margin-right: 0;
 }
 
 .helptext {

--- a/educa/courses/templates/courses/manage/course/list.html
+++ b/educa/courses/templates/courses/manage/course/list.html
@@ -8,7 +8,7 @@
     {% for course in object_list %}
       <div class="course-info">
         <h3>{{ course.title }}</h3>
-        <p>
+        <p class="course-actions">
           <a href="{% url "course_edit" course.id %}">Редактировать</a>
           <a href="{% url "course_delete" course.id %}">Удалить</a>
           <a href="{% url "course_module_update" course.id %}">Редактирование модулей</a>


### PR DESCRIPTION
## Summary
- adjust course management list template to use a dedicated `course-actions` class
- style `course-actions` links and improve module form input widths

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845706215448328958e60b8d2ed645e