### PR TITLE
Fix Russian pluralization

### DIFF
--- a/educa/courses/templates/courses/course/detail.html
+++ b/educa/courses/templates/courses/course/detail.html
@@ -14,7 +14,8 @@
       <p>
         <a href="{% url "course_list_subject" subject.slug %}">
         {{ subject.title }}</a>.
-        {{ object.modules.count }} модули.
+        {{ object.modules.count }}
+        {{ object.modules.count|rupluralize:"модуль,модуля,модулей" }}.
         Преподаватель: {{ object.owner.get_full_name|default:object.owner.username }}
       </p>
       {{ object.overview|linebreaks }}

--- a/educa/courses/templates/courses/course/list.html
+++ b/educa/courses/templates/courses/course/list.html
@@ -27,7 +27,10 @@
           <a href="{% url "course_list_subject" s.slug %}">
             {{ s.title }}
             <br>
-            <span>{{ s.total_courses }} курс</span>
+            <span>
+              {{ s.total_courses }}
+              {{ s.total_courses|rupluralize:"курс,курса,курсов" }}
+            </span>
           </a>
         </li>
       {% endfor %}
@@ -43,7 +46,8 @@
         </h3>
         <p>
           <a href="{% url "course_list_subject" subject.slug %}">{{ subject }}</a>.
-            {{ course.total_modules }} модули.
+            {{ course.total_modules }}
+            {{ course.total_modules|rupluralize:"модуль,модуля,модулей" }}.
             Преподаватель: {{ course.owner.get_full_name|default:course.owner.username }}
         </p>
       {% endwith %}

--- a/educa/courses/templatetags/course.py
+++ b/educa/courses/templatetags/course.py
@@ -9,3 +9,27 @@ def model_name(obj):
         return obj._meta.model_name
     except AttributeError:
         return None
+
+
+@register.filter
+def rupluralize(value, arg=""):
+    """Return the correct Russian plural form for the given number.
+
+    ``arg`` must contain three comma-separated forms (for 1, 2-4 and 5+).
+    Example: ``{{ num|rupluralize:"\u043a\u0443\u0440\u0441,\u043a\u0443\u0440\u0441\u0430,\u043a\u0443\u0440\u0441\u043e\u0432" }}``
+    """
+    forms = [f.strip() for f in arg.split(',')]
+    if len(forms) != 3:
+        return ''
+    try:
+        n = abs(int(value))
+    except (TypeError, ValueError):
+        return ''
+
+    if n % 10 == 1 and n % 100 != 11:
+        form = forms[0]
+    elif 2 <= n % 10 <= 4 and (n % 100 < 10 or n % 100 >= 20):
+        form = forms[1]
+    else:
+        form = forms[2]
+    return form


### PR DESCRIPTION
## Summary
- add `rupluralize` template filter for Russian pluralization rules
- use new filter to pluralize course and module counts

## Testing
- `pytest -q`
- `python educa/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68457172a97c8328b24c65dcc7536940