### PR TITLE
Add universal registration form

### DIFF
--- a/educa/courses/templates/base.html
+++ b/educa/courses/templates/base.html
@@ -26,6 +26,7 @@
           </li>
         {% else %}
           <li><a href="{% url "login" %}">Войти</a></li>
+          <li><a href="{% url "register" %}">Регистрация</a></li>
         {% endif %}
       </ul>
     </div>

--- a/educa/courses/templates/courses/course/detail.html
+++ b/educa/courses/templates/courses/course/detail.html
@@ -36,7 +36,7 @@
           </form>
         {% endif %}
       {% else %}
-        <a href="{% url "student_registration" %}" class="button">
+        <a href="{% url "register" %}" class="button">
           Зарегистрируйтесь, чтобы записаться
         </a>
       {% endif %}

--- a/educa/courses/templates/registration/register.html
+++ b/educa/courses/templates/registration/register.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block title %}Регистрация{% endblock %}
+
+{% block content %}
+  <h1>Регистрация</h1>
+  <div class="module">
+    <p>Введите свои данные для создания учетной записи:</p>
+    <form method="post">
+      {{ form.as_p }}
+      {% csrf_token %}
+      <p><input type="submit" value="Создать учетную запись"></p>
+    </form>
+  </div>
+{% endblock %}

--- a/educa/educa/urls.py
+++ b/educa/educa/urls.py
@@ -21,12 +21,17 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
-from .views import LogoutViewAllowGet
+from .views import LogoutViewAllowGet, UserRegistrationView
 from django.urls import include, path
 
 urlpatterns = [
     path(
         'accounts/login/', auth_views.LoginView.as_view(), name='login'
+    ),
+    path(
+        'accounts/register/',
+        UserRegistrationView.as_view(),
+        name='register',
     ),
     path(
         'accounts/logout/',

--- a/educa/educa/views.py
+++ b/educa/educa/views.py
@@ -1,4 +1,8 @@
 from django.contrib.auth.views import LogoutView
+from django.contrib.auth import authenticate, login
+from django.contrib.auth.forms import UserCreationForm
+from django.urls import reverse_lazy
+from django.views.generic.edit import CreateView
 
 class LogoutViewAllowGet(LogoutView):
     """Allow logout via GET requests for convenience."""
@@ -6,3 +10,20 @@ class LogoutViewAllowGet(LogoutView):
     def get(self, request, *args, **kwargs):
         """Redirect GET requests to POST to avoid CSRF issues with stale pages."""
         return self.post(request, *args, **kwargs)
+
+
+class UserRegistrationView(CreateView):
+    """Register a new user and log them in."""
+
+    template_name = "registration/register.html"
+    form_class = UserCreationForm
+    success_url = reverse_lazy("student_course_list")
+
+    def form_valid(self, form):
+        response = super().form_valid(form)
+        cd = form.cleaned_data
+        user = authenticate(
+            username=cd["username"], password=cd["password1"]
+        )
+        login(self.request, user)
+        return response


### PR DESCRIPTION
## Summary
- add general `UserRegistrationView`
- link new registration page in base template
- show register button on course detail page
- expose `/accounts/register/` URL for all users
- include registration form template

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6845773091e4832897a45a681123b7f8