### PR TITLE
Fix 405 on lesson form save

### DIFF
--- a/educa/courses/views.py
+++ b/educa/courses/views.py
@@ -130,6 +130,15 @@ class ModuleLessonUpdateView(TemplateResponseMixin, View):
             {'module': self.module, 'formset': formset}
         )
 
+    def post(self, request, *args, **kwargs):
+        formset = self.get_formset(data=request.POST)
+        if formset.is_valid():
+            formset.save()
+            return redirect('module_content_list', self.module.id)
+        return self.render_to_response(
+            {'module': self.module, 'formset': formset}
+        )
+
 
 class ModuleTestUpdateView(TemplateResponseMixin, View):
     """Manage tests within a module."""


### PR DESCRIPTION
## Summary
- allow POST for lesson formset in `ModuleLessonUpdateView`

## Testing
- `python educa/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685af4ec7d188328b341f82614e7cb48